### PR TITLE
Add PDF documentation build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ std::list<Node> aStar(
 
 ## Building documentation
 
-Ensure that `sphynx` and `recommonmark` have been installed, then enter the `docs\` directory and run `make [target]`; for a list of targets just run `make`.
+Ensure that `sphynx` and `recommonmark` have been installed, then enter the `docs\` directory and run `make pdf` to build a PDF of the documentation; for a list of targets just run `make`.
 
 To install `sphynx` and `recommonmark` run:
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Type signature of `aStar` search function:
 ```cpp
 template<typename Node, typename Cost, size_t N>
 std::list<Node> aStar(
-    const Node &amp;START,
-    const Node &amp;GOAL,
+    const Node \&START,
+    const Node \&GOAL,
     const Node vertex[N],
     const Cost graph[N][N],
     Cost (*heuristic)(Node current,Node goal));

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,10 +30,11 @@ from recommonmark.parser import CommonMarkParser
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc',
+extensions = ['rst2pdf.pdfbuilder',
+    'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
-    'sphinx.ext.imgmath',
     'sphinx.ext.githubpages']
+
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['.templates']
@@ -192,3 +193,7 @@ html_context = {
     "github_version": "master", # Version
     "conf_py_path": "/docs/", # Path in the checkout to the docs root
 }
+
+
+# -- Options for PDF Output -----------------------------------------------
+pdf_documents = [('index', u'a-star', u'A Star Graph Search', u'Gwen Lofman')]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,7 +64,7 @@ References
 Building documentation
 ======================
 
-Ensure that ``sphinx`` and ``recommonmark`` have been installed, then enter the ``docs\`` directory and run ``make [target]``; for a list of targets just run ``make``.
+Ensure that ``sphinx`` and ``recommonmark`` have been installed, then enter the ``docs\`` directory and run ``make pdf`` to build a PDF of the documentation; for a list of targets just run ``make``.
 
 To install `sphinx` and `recommonmark` run:::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,9 +64,9 @@ References
 Building documentation
 ======================
 
-Ensure that ``sphynx`` and ``recommonmark`` have been installed, then enter the ``docs\`` directory and run ``make [target]``; for a list of targets just run ``make``.
+Ensure that ``sphinx`` and ``recommonmark`` have been installed, then enter the ``docs\`` directory and run ``make [target]``; for a list of targets just run ``make``.
 
-To install `sphynx` and `recommonmark` run:::
+To install `sphinx` and `recommonmark` run:::
 
     $ pip install sphinx sphinx-autobuild
     $ pip install recommonmark


### PR DESCRIPTION
Adds PDF documentation build target with information in README.md and the quick start documentation about the PDF build target.